### PR TITLE
Add `bidiff` delta support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ serde_json = "1.0.83"
 clap = { version = "3.2.16", features = ["derive"] }
 toml = "0.5.9"
 # delta patching
+bidiff = "1.0.0"
+bipatch = "1.0.0"
 bsdiff = "0.1.6"
 xz2 = "0.1.7"
 # singing

--- a/extra/config.example.toml
+++ b/extra/config.example.toml
@@ -48,8 +48,7 @@ exclude = [
 
 ## Delta patch generation
 [generate]
-# Maybe in the future there will be more!
-# patch_type = "bsdiff_lzma"
+patch_type = "bsdiff_lzma"
 
 # eclude files matching these patterns from being removed automatically
 # (e.g. legacy plugins no longer shipped with OBS but aren't broken yet)

--- a/src/steps/generate.rs
+++ b/src/steps/generate.rs
@@ -7,7 +7,7 @@ use hashbrown::{HashMap, HashSet};
 use indicatif::{ParallelProgressIterator, ProgressBar, ProgressFinish, ProgressIterator, ProgressStyle};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
-use crate::models::config::Config;
+use crate::models::config::{Config, PatchType};
 use crate::models::manifest::{FileEntry, Manifest, Package};
 use crate::utils;
 use crate::utils::hash::FileInfo;
@@ -299,7 +299,15 @@ impl<'a> Generator<'a> {
             .with_style(style.clone())
             .with_finish(ProgressFinish::AndLeave);
 
-        println!("[+] Creating delta-patches...");
+        println!(
+            "[+] Creating delta-patches... (using: {:?})",
+            self.config.generate.patch_type
+        );
+        let patch_fun = match self.config.generate.patch_type {
+            PatchType::BsdiffLzma => utils::bsdiff::create_patch,
+            PatchType::BidiffLzma => utils::bidiff::create_patch,
+        };
+
         patch_list_mt
             .par_iter()
             .progress_with(progress_bar_mt)
@@ -312,8 +320,7 @@ impl<'a> Generator<'a> {
                 let outfile = self.out_path.join(patch_filename);
                 // Ensure directories exist (Note: this is thread-safe in Rust!)
                 fs::create_dir_all(outfile.parent().unwrap()).expect("Failed creating folder!");
-                utils::bsdiff::create_patch(&patch.old_file, &patch.new_file, &outfile)
-                    .expect("Creating hash failed horribly.");
+                patch_fun(&patch.old_file, &patch.new_file, &outfile).expect("Creating patch failed horribly.");
             });
 
         // If any patches were assigned to the non-parallel patch list run them here
@@ -332,8 +339,7 @@ impl<'a> Generator<'a> {
                 );
                 let outfile = self.out_path.join(patch_filename);
                 fs::create_dir_all(outfile.parent().unwrap()).expect("Failed creating folder!");
-                utils::bsdiff::create_patch(&patch.old_file, &patch.new_file, &outfile)
-                    .expect("Creating hash failed horribly.");
+                patch_fun(&patch.old_file, &patch.new_file, &outfile).expect("Creating patch failed horribly.");
             });
         }
 

--- a/src/steps/generate.rs
+++ b/src/steps/generate.rs
@@ -248,7 +248,7 @@ impl<'a> Generator<'a> {
                 let package: &String = analysis.package_map.get(filename).unwrap_or(&analysis.default_pkg);
                 let patch_filename = format!("updater/update_studio/{branch}/{package}/{filename}");
                 let updater_file = self.out_path.join(patch_filename);
-                let build_file = self.inp_path.join(&filename);
+                let build_file = self.inp_path.join(filename);
                 fs::create_dir_all(updater_file.parent().unwrap()).expect("Failed creating folder!");
                 fs::copy(build_file, updater_file).expect("Failed copying file!");
             });

--- a/src/utils/bidiff.rs
+++ b/src/utils/bidiff.rs
@@ -3,8 +3,7 @@ use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use anyhow::Result;
-use bsdiff::diff::diff;
-use bsdiff::patch::patch as bspatch;
+
 use xz2::read::XzDecoder;
 use xz2::write::XzEncoder;
 
@@ -13,7 +12,7 @@ use crate::utils::hash::{hash_file, FileInfo};
 // 9 | LZMA_PRESET_EXTREME
 const LZMA_PRESET: u32 = 9 | 1 << 31;
 
-/// Create OBS-bsdiff compatible patch file (bsdiff + LZMA)
+/// Create OBS-bidiff compatible patch (bidiff + LZMA)
 pub fn create_patch(old: &Path, new: &Path, patch: &Path) -> Result<FileInfo> {
     let mut old_file = File::open(old).expect("Unable to open old file");
     let mut new_file = File::open(new).expect("Unable to open new file");
@@ -29,60 +28,60 @@ pub fn create_patch(old: &Path, new: &Path, patch: &Path) -> Result<FileInfo> {
     let mut out_data = Cursor::new(Vec::new());
     let mut writer = XzEncoder::new(&mut out_data, LZMA_PRESET);
 
-    diff(&old_buf, &new_buf, &mut writer)?;
+    bidiff::simple_diff(&old_buf, &new_buf, &mut writer)?;
     writer.finish()?;
 
-    patch_file.write_all(b"JIMSLEY/BSDIFF43")?;
+    patch_file.write_all(b"BOUF/BIDIFF/LZMA")?;
     patch_file.write_all(&((new_buf.len() as u64).to_le_bytes()))?;
     patch_file.write_all(out_data.get_ref())?;
 
     Ok(hash_file(patch))
 }
 
-/// Apply OBS-bsdiff patch
+/// Apply OBS-bidiff patch
 // This function is not implemented in the most memory-efficient way,
 // it's only needed for testing though.
 #[allow(dead_code)]
 pub fn apply_patch(old: &Path, new: &Path, patch: &Path) -> Result<FileInfo> {
-    let mut old_file = File::open(old).expect("Unable to open old file");
-    let mut new_file = File::create(new).expect("Unable to open new file");
+    let old_file = File::open(old).expect("Unable to open old file");
     let patch_file = File::open(patch).expect("Unable to open patch file");
+    let mut new_file = File::create(new).expect("Unable to open new file");
 
-    let mut old_buf = Vec::new();
-    old_file.read_to_end(&mut old_buf)?;
-
-    let mut patch_data = BufReader::new(patch_file);
+    let mut old_reader = BufReader::new(old_file);
+    let mut patch_reader = BufReader::new(patch_file);
     // Skip header
-    patch_data.seek(SeekFrom::Start(16))?;
+    patch_reader.seek(SeekFrom::Start(16))?;
     // Read size of output file
     let mut size_buf = [0; 8];
-    patch_data.read_exact(&mut size_buf)?;
+    patch_reader.read_exact(&mut size_buf)?;
     let size = u64::from_le_bytes(size_buf) as usize;
     // Create LZMA reader
-    let mut reader = XzDecoder::new(&mut patch_data);
+    let reader = XzDecoder::new(&mut patch_reader);
     // Create new buffer and patch it
     let mut new_buf = vec![0; size];
-    bspatch(&old_buf, &mut reader, &mut new_buf)?;
+
+    let mut r = bipatch::Reader::new(reader, &mut old_reader)?;
+    let _read = r.read(&mut new_buf)?;
     new_file.write_all(&new_buf)?;
 
     Ok(hash_file(new))
 }
 
 #[cfg(test)]
-mod bsdiff_tests {
+mod bidiff_tests {
     use super::*;
 
     #[test]
-    fn test_diff() {
+    fn test_bidiff() {
         // First, create the patch
         let old = Path::new("extra/test_files/in.txt");
         let new = Path::new("extra/test_files/out.txt");
-        let patch = Path::new("extra/test_files/patch.bin");
+        let patch = Path::new("extra/test_files/patch_bidiff.bin");
         let patch_info = create_patch(old, new, patch).unwrap();
-        assert_eq!(patch_info.hash, "cc44d732f2f07d39fa556c2d7336da73e1671783");
+        assert_eq!(patch_info.hash, "4226ea4d16e4dd9df13840d90bd64918f0f7a1e6");
 
         // Try applying the patch
-        let out = Path::new("extra/test_files/out_test.txt");
+        let out = Path::new("extra/test_files/out_test_bidiff.txt");
         let res = apply_patch(old, out, patch).unwrap();
         assert_eq!(res.hash, "50b242bcef918cc8363e9cf1a27a1420928948e9");
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod bidiff;
 pub mod bsdiff;
 pub mod hash;
 pub mod misc;


### PR DESCRIPTION
### Description

Add option to use [bidiff](https://github.com/divvun/bidiff) to create patch files instead of bsdiff.

### Motivation and Context

- Reduces memory footprint during delta creation by 50% (especially for CEF deltas)
- Reduces time to create deltas by 25%

Possibly makes it viable to run delta creation on CI runners without running out of memory or taking forever.

### How Has This Been Tested?

Locally, not implemented in OBS yet.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
