### PR TITLE
Use custom bsdiff to fix debug recursion crash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0.83"
 clap = { version = "3.2.16", features = ["derive"] }
 toml = "0.5.9"
 # delta patching
-bsdiff = "0.1.6"
+bsdiff = { git = "https://github.com/jp9000/bsdiff-rs", branch = "tail-end-optimization" }
 xz2 = "0.1.7"
 # singing
 base64 = "0.13.0"

--- a/src/utils/bsdiff.rs
+++ b/src/utils/bsdiff.rs
@@ -2,8 +2,8 @@ use std::fs::File;
 use std::io::{BufReader, Cursor, Read, Result, Seek, SeekFrom, Write};
 use std::path::Path;
 
-use bsdiff::diff::diff;
-use bsdiff::patch::patch as bspatch;
+use bsdiff::diff;
+use bsdiff::patch as bspatch;
 use xz2::read::XzDecoder;
 use xz2::write::XzEncoder;
 

--- a/src/utils/bsdiff.rs
+++ b/src/utils/bsdiff.rs
@@ -60,7 +60,7 @@ pub fn apply_patch(old: &Path, new: &Path, patch: &Path) -> Result<FileInfo> {
     // Create LZMA reader
     let mut reader = XzDecoder::new(&mut patch_data);
     // Create new buffer and patch it
-    let mut new_buf = vec![0; size];
+    let mut new_buf = Vec::with_capacity(size);
     bspatch(&old_buf, &mut reader, &mut new_buf)?;
     new_file.write_all(&new_buf)?;
 


### PR DESCRIPTION
### Description

bsdiff likes to use recursion pretty heavily in its `split` function, but because rust uses a fairly significant amount of stack space when building with debug, it causes the program to crash on certain files. Instead of using recursion, use a manually-written tail-end optimization to fix it.

The `bsdiff::diff::split` function now uses a while loop instead of recursion for its last split call.

### Motivation and Context

Don't want crashing when running bouf in debug.

### How Has This Been Tested?

Seems to work. Could use some verification. Check The changes in `bsdiff/diff.rs`

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
