### PR TITLE
Only copy relevant files during preparation

### DIFF
--- a/src/steps/prepare.rs
+++ b/src/steps/prepare.rs
@@ -72,8 +72,16 @@ impl<'a> Preparator<'a> {
         {
             let file: DirEntry = file;
             // Get a path relative to the input directory for lookup/copy path
-            let relative_path = file.path().strip_prefix(&self.input_path).unwrap().to_str().unwrap();
-            let relative_path_str = String::from(relative_path).replace('\\', "/");
+            let relative_path = file.path().strip_prefix(&self.input_path).unwrap();
+            let relative_path_str = String::from(relative_path.to_str().unwrap()).replace('\\', "/");
+
+            if !relative_path.starts_with("bin")
+                && !relative_path.starts_with("data")
+                && !relative_path.starts_with("obs-plugins")
+            {
+                continue;
+            }
+
             // Check against overrides
             if overrides.contains(&relative_path_str) {
                 continue;


### PR DESCRIPTION
### Description
Otherwise it'll add the .gitignore and any other files that happen to be in the base directory. I had about 2 gigabytes worth of zip files and it didn't go well.

### Motivation and Context
Copied all the files that happened to be alongside `bin`/`data`/`obs-plugins`, ended up with a zip file the size of manhattan.

### How Has This Been Tested?
By using it

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
