### PR TITLE
Rework file filtering, cleanup, and add some documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ toml = "0.7.0"
 bsdiff = { git = "https://github.com/space-wizards/bsdiff-rs", rev = "a77199a6dd31d90555b4efd2c57d91d3aa3b69e5" }
 xz2 = "0.1.7"
 zstd = "0.12.2"
+object = { version = "0.30.3", features = ["read"] }
 # singing
 base64 = "0.13.0"
 rsa = { version = "0.8", features = ["sha2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bouf"
-version = "0.4.4"
-authors = ["Dennis <dennis@obsproject.com>"]
+version = "0.5.0"
+authors = ["Dennis Sädtler <dennis@obsproject.com>"]
 edition = "2021"
 autobins = false
 

--- a/README.md
+++ b/README.md
@@ -1,60 +1,12 @@
 # BOUF - Building OBS Updates Fast(er)
 
-`bouf` is the next-generation utility for preparing and building OBS Studio Windows release binaries and updater delta patches.
+`bouf` is the application used for preparing and building OBS Studio Windows release distribution packages and updater delta patches.
 
-The main binary `bouf` automates the entire process based on the rules laid out in the config file and command line.
+See [docs](docs/README.md) for more information.
 
-The generated output has the following structure:
+## Usage
 
-* `install/` - OBS install files used to build installer/zip files (signed)
-* `updater/`
-  + `patches_studio/[branch]/{core,obs-browser}` - delta patches for upload to server 
-  + `update_studio/[branch]/{core,obs-browser}` - files split into packages for upload to server
-* `pdbs/` - Full PDBs
-* `manifest[_<branch>].json` and `manifest[_<branch>].json.sig` for updater
-* `added.txt`, `changed.txt`, `unchanged.txt`, and `removed.txt` for manual checks 
-* `OBS-Studio-<version>-Installer.exe` - NSIS installer (signed)
-* `OBS-Studio-<version>.zip` - ZIP file of `install/`
-* `OBS-Studio-<version>-pdbs.zip` - Archive of unstripped PDBs
-
-Additionally, the following utilities are provided:
-* `bouf-sign` to sign files verified by the OBS updater (manifest, updater.exe, whatsnew, branches, etc.)
-* `bouf-deltas` to create delta patches and nothing else
-
-## Usage:
-
-```
-Usage: bouf.exe [OPTIONS] --config <config.toml> --version <Major.Minor.Patch[-(rc|beta)Num]>
-
-Options:
-  -c, --config <config.toml>                        Configuration file
-  -v, --version <Major.Minor.Patch[-(rc|beta)Num]>  OBS main version
-      --beta <Beta number>                          Beta number
-      --rc <RC number>                              RC number
-      --branch <Beta branch>                        Branch used in manifest name/update files
-      --commit <commit hash>                        Commit hash used in manifest
-  -i, --input <new build>
-  -p, --previous <old builds>
-  -o, --output <output dir>
-      --notes-file <file.rtf>                       File containing release notes
-      --private-key <file.pem>                      Falls back to "UPDATER_PRIVATE_KEY" env var
-      --include <FILTER>
-      --exclude <FILTER>
-      --updater-data-only                           Create only delta patches and manifest
-      --skip-installer                              Skip creating NSIS installer
-      --skip-patches                                Skip creating delta patches
-      --skip-codesigning                            Skip codesigning
-      --skip-manifest-signing                       Skip signing manifest
-      --clear-output                                Clear existing output directory
-  -h, --help                                        Print help (see more with '--help')
-  -V, --version                                     Print version
-```
-
-
-**Note:** A valid configuration file based on `extra/config.example.toml` is required (see `extra/ci` for an example).
-
-Some parameters can be set via environment variables (e.g. secrets):
-- `UPDATER_PRIVATE_KEY` - updater signing key (PEM, encoded as base64)
+See [docs/cli](docs/cli.md) and [docs/config](docs/config.md) for usage details.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# Overview
+
+The main binary `bouf` automates the entire process based on the rules laid out in the config file and command line.
+
+Additionally, the following utilities are provided:
+- `bouf-sign` - utility for quickly RSA-signing manifest or other files validated by OBS on download
+- `bouf-deltas` - stripped down version of bouf only handling generation of delta patches
+
+bouf gets its name - Building OBS Updates Fast(er) - from providing a number of optimisations over the legacy update builder.
+It was built to be highly configurable and more easily extendable compared to the previous tooling.
+
+New features compared to legacy tool:
+- Parallelisation of file hashing and patch generations
+- Zstandard instead of bsdiff
+- Support for update branches
+- Updated NSIS scripts
+- Automatic exclusion of files whose executable contents have not changed
+- It's written in Rust, of course :p
+
+## Usage Documentation
+
+- [cli](cli.md) contains documentation on CLI usage
+- [config](config.md) contains documentation on the config file format and keys
+
+## General Notes
+
+The generated output from bouf has the following structure:
+
+* `install/` - OBS install files used to build installer/zip files (signed)
+* `updater/`
+    + `patches_studio/[branch]/[package]/{file}` - delta patches for upload to server
+    + `update_studio/[branch]/[package]/{file}` - files split into packages for upload to server
+* `pdbs/` - Full PDBs
+* `manifest[_<branch>].json` and `manifest[_<branch>].json.sig` for updater
+* `added.txt`, `changed.txt`, `unchanged.txt`, and `removed.txt` for manual checks
+* `OBS-Studio-<version>-Installer.exe` - NSIS installer (signed)
+* `OBS-Studio-<version>.zip` - ZIP file of `install/`
+* `OBS-Studio-<version>-pdbs.zip` - Archive of unstripped PDBs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,84 @@
+# Command Line Interface (CLI)
+
+The command line interface allows a number of options to by dynamically set without having to modify the config file each time.
+This includes things that are expected to change each time such as the version, as well as a few other things to make
+testing more bearable (e.g. skipping installer creation).
+
+**Note:** A valid configuration fileis required (see [config](config.md) and `extra/config.example.toml`).
+
+Some parameters can be set via environment variables (e.g. secrets):
+- `UPDATER_PRIVATE_KEY` - updater signing key (PEM, encoded as base64)
+
+## Minimal example
+
+The parameters `--config` and `--version` are required to be set.
+See [config](config.md) for required config options.
+
+```
+# bould main bouf exe
+cargo build -r --bin bouf
+# run bouf with config
+./target/release/bouf -c config.toml --version 29.1.0-beta1
+```
+
+## Full help text
+```
+Building OBS Updates Fast(er)
+
+Usage: bouf [OPTIONS] --config <config.toml> --version <Major.Minor.Patch[-(rc|beta)Num]>
+
+Options:
+  -c, --config <config.toml>
+          Configuration file
+
+  -v, --version <Major.Minor.Patch[-(rc|beta)Num]>
+          OBS main version
+
+      --beta <Beta number>
+          Beta number
+
+      --rc <RC number>
+          RC number
+
+      --branch <Beta branch>
+          Branch used in manifest name/update files
+
+      --commit <commit hash>
+          Commit hash used in manifest
+
+  -i, --input <new build>
+
+  -p, --previous <old builds>
+
+  -o, --output <output dir>
+
+      --notes-file <file.rtf>
+          File containing release notes
+
+      --private-key <file.pem>
+          Falls back to "UPDATER_PRIVATE_KEY" env var
+
+      --updater-data-only
+          Create only delta patches and manifest
+
+      --skip-installer
+          Skip creating NSIS installer
+
+      --skip-patches
+          Skip creating delta patches
+
+      --skip-codesigning
+          Skip codesigning
+
+      --skip-manifest-signing
+          Skip signing manifest
+
+      --clear-output
+          Clear existing output directory
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -85,13 +85,15 @@ e.g. when the files are from version that are no longer included in the `previou
 
 ### `[package.installer]` Subsection
 
-- `nsis_script` (path) - Path to NSIS script (**required**)
+- `skip` (bool) - Whether to skip creating the installer (default: `false`)
 - `skip_sign` (bool) - Whether to skip signing the installer (default: `false`)
+- `nsis_script` (path) - Path to NSIS script (**required** if `skip` is `false`)
 
 ### `[package.updater]` Subsection
 
 - `notes_file` (path) - Path to file containing release notes (RST format) (**required** if not set via command line instead)
 - `vc_redist_path` (path) - VC++ redist file which's hash shall be included in the manifest (**required**)
+- `pretty_json` (bool) - Whether to pretty-print JSON manifest (default: `false`)
 
 *Signing options:*
 - `skip_sign` (bool) - Whether to skip signing the manifest (default: `false`)
@@ -101,8 +103,8 @@ e.g. when the files are from version that are no longer included in the `previou
 
 ### `[package.zip]` Subsection
 
-- `name` (string) - Name of ZIP file containing the OBS release build (**required**)
-- `pdb_name` (string) - Name of ZIP file containing unstripped PDBs for this release build (**required**)
+- `name` (string) - Name of ZIP file containing the OBS release build (defaults: `OBS-Studio-{version}.zip`)
+- `pdb_name` (string) - Name of ZIP file containing unstripped PDBs for this release build (default: `OBS-Studio-{version}-pdbs.zip`)
 
 **Note:** Both support the `{version}` placeholder to be replaced with the OBS version.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,113 @@
+# Configuration File
+
+bouf was designed to be very configurable to avoid hardcoding things as much as possible, however,
+there are reasonable defaults for things that do not need to be explicitly set.
+
+See the sections below for detailed explanations of all the options.
+Also see `extra/config.example.toml` for a complete example configuration file.
+
+Keys are optional unless noted otherwise. 
+
+The bouf configuration file uses the [TOML](https://toml.io/en/) format.
+
+## `[env]` Section
+
+todo move this *somewhere*
+- `branch` (string) - updater branch to use in path/manifest (default: `stable`)
+
+*Locations (**required** to be set in the config **or** command line):*
+- `input_dir` (path) - directory containing new build
+- `output_dir` (path) - directory where data (manifest, ZIPs, installer, updater data) will be written to
+- `previous_dir` (path) - directory containing old builds
+
+**Note:** that all of these can be specified via the command line.
+Additionally, both `input_dir` and `output_dir` must exist.
+
+*Tool paths (**required** if binaries not in `%PATH%`/`$PATH`):*
+- `sevenzip_path` (path) - Path to 7-zip CLI executable
+- `makensis_path` (path) - Path to makensis executable
+- `pandoc_path` (path) - Path to pandoc executable
+- `pdbcopy_path` (path) - Path to pandoc executable
+
+## `[prepare]` Section
+
+- `empty_output_dir` (bool) - Clear the output directory if it is not empty, abort and show an error otherwise (default: `false`)
+
+### `[prepare.copy]` Subsection
+
+*Filters:*
+- `never_copy` (array of string) - list of filenames/paths that should never be copied to the output directory (e.g. 32-bit files)
+- `always_copy` (array of string) - list of filenames/paths that should always be copied from the input directory (e.g. main OBS exe) (default: `["obs64", "obspython", "obslua", "obs-frontend-api", "obs.dll", "obs.pdb"]`)
+
+*Overrides/External includes:*
+- `overrides` (array of [string, string] tuples) - files to be copied to the output from external paths (e.g. game capture)
+
+### `[prepare.codesign]` Subsection
+
+- `skip_sign` (bool) - Skip singing (default: `false`)
+- `sign_exts` (array of strings) - file extensions to sign (default: `['exe', 'dll', 'pyd']`)
+
+*signtool parameters (**required** if `skip_sign` is not `true`):*
+- `sign_name` (string) - Name of signing certification in certificate store (signtool `/n` parameter)
+- `sign_digest` (string) - Hash algorithm to use in signature (signtool `/fd` parameter)
+- `sign_ts_serv` (string) - URL of timestamp server to use (signtool `/t` parameter)
+
+## `[prepare.strip_pdbs]` Subsection
+
+- `skip_for_prerelease` (bool) - Skip PDB stripping for pre-release builds (default: `false`)
+- `exclude` (array of filenames) - PDB filenames to exclude from stripping
+
+## `[generate]` Section
+
+- `patch_type` (string) - Type of patch to generate, can be `zstd` or `bsdiff_lzma` (default: `zstd`)
+- `compress_files` (bool) - Compress non-patch files (default: `true`)
+
+*Filters:*
+- `exclude_from_parallel` (array of filenames) - Do not process these files in parallel (e.g. CEF on a RAM-limited machine)
+- `exclude_from_removal` (array of filenames) - Do not add these files to the removed files list
+- `removed_files` (array of filenames) - Additional files to add to the removed files list
+
+**Note:** bouf will automatically determine a list of deleted files based on which ones appear in older build folders but not the input.
+Exclusions are meant for legacy modules that are no longer shipped (e.g. win-mf) so that existing setups continue to work.
+Additional deleted files may be specified in cases where the automatic detection will not pick them up,
+e.g. when the files are from version that are no longer included in the `previous_dir` folder.
+
+### `[[generate.packages]]` Subsections
+
+**Note:** This is an array of tables (see [TOML Documentation](https://toml.io/en/v1.0.0#array-of-tables)) and can exist multiple times.  
+**Note 2:** If omitted, all files are assigned to a package called `core`.  
+**Note 3:** The packages are processed in the order specified, files will be added to the first one that matches. 
+
+- `name` (string) - Name of the package (**required**)
+- `include_files` (array of strings) - file/path names to include in this package
+
+## `[package]` Section
+
+### `[package.installer]` Subsection
+
+- `nsis_script` (path) - Path to NSIS script (**required**)
+- `skip_sign` (bool) - Whether to skip signing the installer (default: `false`)
+
+### `[package.updater]` Subsection
+
+- `notes_file` (path) - Path to file containing release notes (RST format) (**required** if not set via command line instead)
+- `vc_redist_path` (path) - VC++ redist file which's hash shall be included in the manifest (**required**)
+
+*Signing options:*
+- `skip_sign` (bool) - Whether to skip signing the manifest (default: `false`)
+- `private_key` (path) - Path to private key file (**required** if not skipped and not set via environment)
+
+**Note:** The private key may instead be specified via a base64 PEM/DER key in the `UPDATER_PRIVATE_KEY` environment variable.
+
+### `[package.zip]` Subsection
+
+- `name` (string) - Name of ZIP file containing the OBS release build (**required**)
+- `pdb_name` (string) - Name of ZIP file containing unstripped PDBs for this release build (**required**)
+
+**Note:** Both support the `{version}` placeholder to be replaced with the OBS version.
+
+- `skip_pdbs_for_prerelease` (bool) - Whether to skip zipping PDBs for pre-release versions (default: `false`)
+
+## `[post]` Section
+
+- `copy_to_old` (bool) - Whether to copy the final directory to `previous_dir` (default: `false`)

--- a/extra/config.example.toml
+++ b/extra/config.example.toml
@@ -1,6 +1,7 @@
-[env]
 # Branch can be set via command line as well, empty will genreate backwards-compatible update structure
-branch = ""
+branch = "stable"
+
+[env]
 # Directories for building (can be overriden via command line)
 input_dir = "C:/Path/to/build"
 output_dir = "C:/Path/to/output"
@@ -124,8 +125,6 @@ skip_sign = false
 # Note: {version} will be <Major>.<Minor>[.<Patch>] and suffixied with "-rc<Num>" or "-beta<Num>" if provided
 name = "OBS-Studio-{version}.zip"
 pdb_name = "OBS-Studio-{version}-pdbs.zip"
-# Skip PDB generation for pre-release
-skip_pdbs_for_prerelease = true
 
 [package.updater]
 skip_sign = true
@@ -135,6 +134,8 @@ private_key = "C:/Path/to/privkey.pem"
 vc_redist_path = "C:/path/to/vcredist"
 # File containing release notes, should be a pandoc compatible format (e.g. RST or Markdown)
 notes_file = "C:/path/to/release_notes.rst"
+# Pretty print JSON manifest
+pretty_json = true
 
 [post]
 # move processed input directory to "previous" folder after packaging is done

--- a/extra/config.example.toml
+++ b/extra/config.example.toml
@@ -34,24 +34,11 @@ always_copy = [
     "obs.pdb"
 ]
 
-# Overrides/adds files during copy step. These files will NOT be signed or stripped
-# overrides = [
-#     ["data/obs-plugins/win-capture/graphics-hook64.dll", "C:/path/to/override/graphics-hook64.dll"],
-#     ["data/obs-plugins/win-capture/graphics-hook64.pdb", "C:/path/to/override/graphics-hook64.pdb"],
-# ]
-
 # Overrides/adds files during copy step. These files WILL be signed and stripped
-# overrides_sign = [
-#     ["data/obs-plugins/win-capture/graphics-hook32.dll", "C:/path/to/override/graphics-hook32.dll"],
-#     ["data/obs-plugins/win-capture/graphics-hook32.pdb", "C:/path/to/override/graphics-hook32.pdb"],
-# ]
-
-# NOTE: The following two options are mutually exclusive
-# NOTE 2: The following two options only apply to binaries (.pdb, .exe, .dll, .pyd)
-# Files matching these will be copied from the latest previous build instead
-# exclude = ["win-capture"]
-# Files not matching these will be copied from the latest previous build instead
-# include = ["win-dshow"]
+overrides = [
+    ["data/obs-plugins/win-capture/graphics-hook32.dll", "C:/path/to/override/graphics-hook32.dll"],
+    ["data/obs-plugins/win-capture/graphics-hook32.pdb", "C:/path/to/override/graphics-hook32.pdb"],
+]
 
 [prepare.codesign]
 skip_sign = false
@@ -93,9 +80,6 @@ removed_files = [
     "obs-plugins/64bit/decklink-ouput-ui.dll"
 ]
 
-# not implemented yet
-# skip_for_prerelease = true
-
 # Packages are processed in the specified order.
 # A package without include filters will be assigned any remaining files
 [[generate.packages]]
@@ -134,8 +118,6 @@ name = "core"
 
 [package.installer]
 nsis_script = "C:/Path/to/installer.nsi"
-# not implemented yet (requires NSIS script updates)
-# name = "OBS-Studio-{version}.exe"
 skip_sign = false
 
 [package.zip]
@@ -149,8 +131,7 @@ skip_pdbs_for_prerelease = true
 skip_sign = true
 # alternatively, the key may be specified as base64 encoded PEM/DER in an environment variables (UPDATER_PRIVATE_KEY)
 private_key = "C:/Path/to/privkey.pem"
-# not implemented yet (use bouf-sign to sign updater.exe separately if required)
-# updater_path = "C:/Path/to/updater.exe"
+# path to vc redistributables (hash is in manifest)
 vc_redist_path = "C:/path/to/vcredist"
 # File containing release notes, should be a pandoc compatible format (e.g. RST or Markdown)
 notes_file = "C:/path/to/release_notes.rst"

--- a/extra/config.minimal_example.toml
+++ b/extra/config.minimal_example.toml
@@ -1,0 +1,20 @@
+[env]
+input_dir = "C:/Path/to/build"
+output_dir = "C:/Path/to/output"
+previous_dir = "C:/path/to/previous/versions"
+
+sevenzip_path = "C:/Program Files/7-Zip/7z.exe"
+makensis_path = "C:/Program Files (x86)/NSIS/makensis.exe"
+pandoc_path = "C:/Dev/obs/obs-patchgenerator-rs/rundir/pandoc.exe"
+pdbcopy_path = "C:/Program Files (x86)/Windows Kits/10/Debuggers/x64/pdbcopy.exe"
+
+[prepare.codesign]
+skip_sign = true
+
+[package.installer]
+skip = true
+
+[package.updater]
+skip_sign = true
+vc_redist_path = "C:/path/to/vcredist"
+notes_file = "C:/path/to/release_notes.rst"

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> Result<()> {
 
     let packager = Packaging::init(&conf);
     // Create NSIS/ZIP
-    if !args.skip_installer && !args.updater_data_only {
+    if !conf.package.installer.skip && !args.updater_data_only {
         println!("[+] Creating Installer");
         packager.run_nsis().context("[!] NSIS creation/signing failed")?;
     } else {

--- a/src/models/args.rs
+++ b/src/models/args.rs
@@ -46,12 +46,6 @@ pub struct MainArgs {
     #[arg(long, value_name = "file.pem")]
     pub private_key: Option<PathBuf>,
 
-    // Optional filters
-    #[arg(long, value_name = "FILTER", conflicts_with = "exclude")]
-    pub include: Option<Vec<String>>,
-    #[arg(long, value_name = "FILTER", conflicts_with = "include")]
-    pub exclude: Option<Vec<String>>,
-
     // Optional flags
     /// Create only delta patches and manifest
     #[arg(long, default_value_t = false)]

--- a/src/steps/generate.rs
+++ b/src/steps/generate.rs
@@ -250,7 +250,7 @@ impl<'a> Generator<'a> {
             .with_finish(ProgressFinish::AndLeave);
 
         let comp_map = Arc::new(Mutex::new(&mut analysis.compressed_map));
-        let branch = &self.config.env.branch;
+        let branch = &self.config.branch;
         println!("[+] Copying/Compressing new build to updater structure...");
         analysis
             .input_map
@@ -311,7 +311,7 @@ impl<'a> Generator<'a> {
             })
             .collect();
 
-        let branch = &self.config.env.branch;
+        let branch = &self.config.branch;
         let num = patch_list_mt.len() as u64;
 
         let style =

--- a/src/steps/package.rs
+++ b/src/steps/package.rs
@@ -106,18 +106,13 @@ impl<'a> Packaging<'a> {
         let pdb_zip_path = self.config.env.output_dir.join(pdb_zip_name);
 
         run_sevenzip(&self.config.env.sevenzip_path, &obs_path, &obs_zip_path)?;
-        let is_prerelease = self.config.obs_version.rc > 0
-            || self.config.obs_version.beta > 0
-            || !self.config.obs_version.commit.is_empty();
-        if !(self.config.package.zip.skip_pdbs_for_prerelease && is_prerelease) {
-            run_sevenzip(&self.config.env.sevenzip_path, &pdb_path, &pdb_zip_path)?;
-        }
+        run_sevenzip(&self.config.env.sevenzip_path, &pdb_path, &pdb_zip_path)?;
 
         Ok(())
     }
 
     pub fn finalise_manifest(&self, manifest: &mut Manifest) -> Result<PathBuf> {
-        let branch = &self.config.env.branch;
+        let branch = &self.config.branch;
 
         let manifest_filename = if branch.is_empty() || branch == "stable" {
             "manifest.json".to_string()


### PR DESCRIPTION
### Description

- Adds some documentation for config and CLI
- Rework how filtering works, removing manual options in favour of automatic code-only hashing
- Add previously missing config validation checks
- Cleanup

### Motivation and Context

Automate include/exclude filters.

### How Has This Been Tested?

Tested with beta3 -> beta4, will need more testing.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
