### PR TITLE
Support Delta Bundles

### DIFF
--- a/src/utils/hash.rs
+++ b/src/utils/hash.rs
@@ -215,6 +215,21 @@ pub fn get_dir_code_hashes(path: &PathBuf) -> HashMap<String, FileInfo> {
     hashes
 }
 
+pub fn hash_string(input: &String) -> String {
+    let mut hash_buf = [0u8; 20];
+    let mut hasher = Blake2bVar::new(BLAKE2_HASH_SIZE).unwrap();
+
+    hasher.update(input.as_bytes());
+    hasher.finalize_variable(&mut hash_buf).unwrap();
+
+    let mut s = String::with_capacity(2 * BLAKE2_HASH_SIZE);
+    for byte in hash_buf {
+        write!(s, "{byte:02x}").unwrap();
+    }
+
+    s
+}
+
 #[cfg(test)]
 mod hash_tests {
     use super::*;


### PR DESCRIPTION
### Description

Adds support for combining all delta patches for one version into a bundle that can be downloaded as one file instead of multiple separate ones.

### Motivation and Context

Improves updater speed at cost of some server storage.

### How Has This Been Tested?

Tested locally with OBS PR (https://github.com/obsproject/obs-studio/pull/8815) merged and test URLs set.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
