### PR TITLE
extra/nsis: Add shader cache removal

### DIFF
--- a/extra/nsis/mp-installer.nsi
+++ b/extra/nsis/mp-installer.nsi
@@ -373,9 +373,10 @@ Section "un.${APPNAME} App Files" UninstallSection1
 
 	SectionIn RO
 
-	; Remove hook files and vulkan registry
+	; Remove hook files, shader cache, and vulkan registry
 	SetShellVarContext all
 
+	RMDir /r "$APPDATA\obs-studio\shader-cache"
 	RMDir /r "$APPDATA\obs-studio-hook"
 
 	SetRegView 32


### PR DESCRIPTION
### Description

Cleans up shader cache files introduced with https://github.com/obsproject/obs-studio/pull/9249 when uninstalling.

### Motivation and Context

Want to not leave unused files kicking about.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
