### PR TITLE
Clean up Windows Start Menu entry

### DIFF
--- a/extra/nsis/mp-installer.nsi
+++ b/extra/nsis/mp-installer.nsi
@@ -234,7 +234,7 @@ Function checkFilesInUse
 FunctionEnd
 
 Function LaunchOBS
-	Exec '"$WINDIR\explorer.exe" "$SMPROGRAMS\OBS Studio\OBS Studio (64bit).lnk"'
+	Exec '"$WINDIR\explorer.exe" "$SMPROGRAMS\OBS Studio.lnk"'
 FunctionEnd
 
 Section "OBS Studio" SecCore
@@ -303,12 +303,8 @@ Section "OBS Studio" SecCore
 	SetOutPath "$INSTDIR\bin\64bit"
 	CreateShortCut "$DESKTOP\OBS Studio.lnk" "$INSTDIR\bin\64bit\obs64.exe"
 
-	CreateDirectory "$SMPROGRAMS\OBS Studio"
-
 	SetOutPath "$INSTDIR\bin\64bit"
-	CreateShortCut "$SMPROGRAMS\OBS Studio\OBS Studio (64bit).lnk" "$INSTDIR\bin\64bit\obs64.exe"
-
-	CreateShortCut "$SMPROGRAMS\OBS Studio\Uninstall.lnk" "$INSTDIR\uninstall.exe"
+	CreateShortCut "$SMPROGRAMS\OBS Studio.lnk" "$INSTDIR\bin\64bit\obs64.exe"
 SectionEnd
 
 Section -FinishSection
@@ -413,9 +409,8 @@ Section "un.${APPNAME} App Files" UninstallSection1
 	SetShellVarContext all
 	Delete "$DESKTOP\OBS Studio.lnk"
 	Delete "$SMPROGRAMS\OBS Studio\OBS Studio (32bit).lnk"
-	Delete "$SMPROGRAMS\OBS Studio\Uninstall.lnk"
 	${if} ${RunningX64}
-		Delete "$SMPROGRAMS\OBS Studio\OBS Studio (64bit).lnk"
+		Delete "$SMPROGRAMS\OBS Studio.lnk"
 	${endif}
 	SetShellVarContext current
 

--- a/extra/nsis/mp-installer.nsi
+++ b/extra/nsis/mp-installer.nsi
@@ -305,6 +305,11 @@ Section "OBS Studio" SecCore
 
 	SetOutPath "$INSTDIR\bin\64bit"
 	CreateShortCut "$SMPROGRAMS\OBS Studio.lnk" "$INSTDIR\bin\64bit\obs64.exe"
+
+	; Delete old Start Menu shortcuts if installing upon an older version
+	Delete "$SMPROGRAMS\OBS Studio\OBS Studio (64bit).lnk"
+	Delete "$SMPROGRAMS\OBS Studio\Uninstall.lnk"
+	RMDir "$SMPROGRAMS\OBS Studio"
 SectionEnd
 
 Section -FinishSection
@@ -409,7 +414,9 @@ Section "un.${APPNAME} App Files" UninstallSection1
 	SetShellVarContext all
 	Delete "$DESKTOP\OBS Studio.lnk"
 	Delete "$SMPROGRAMS\OBS Studio\OBS Studio (32bit).lnk"
+	Delete "$SMPROGRAMS\OBS Studio\Uninstall.lnk"
 	${if} ${RunningX64}
+		Delete "$SMPROGRAMS\OBS Studio\OBS Studio (64bit).lnk"
 		Delete "$SMPROGRAMS\OBS Studio.lnk"
 	${endif}
 	SetShellVarContext current


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Simplifies the Start Menu entries created by the Windows installer to just one entry, in order to make it appear cleaner and modern.

### Motivation and Context
Why have a Start Menu folder when it is just one entry (plus the uninstaller shortcut, but it is hidden since W10, so removal is appropriate and it is practically only one entry).

### How Has This Been Tested?
Viewed on W10. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
